### PR TITLE
Reduced image size to 33% of original size + dynamic composer checksum

### DIFF
--- a/config/getcomposer.sh
+++ b/config/getcomposer.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -o errexit
+
+EXPECTED_SIGNATURE="$(wget -q -O - https://composer.github.io/installer.sig)"
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE="$(php -r "echo hash_file('SHA384', 'composer-setup.php');")"
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --install-dir=/usr/local/bin --filename=composer
+php -r "unlink('composer-setup.php');"
+#php composer-setup.php --quiet
+if [ -f "composer-setup.php" ]; then rm composer-setup.php ; fi


### PR DESCRIPTION
- Used two-stage build to produce image that is ~250 MB vs. ~775 MB on DockerHub
- Instead of hardcoding checksum for composed, dynamically check against checksum downloaded
- Minor modifications to get working locally (libpng12-dev --> libpng-dev, install gnupg2)